### PR TITLE
Swap to the perfield_builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,9 @@ Search via Cirrus, supports ElasticSearch and OpenSearch, we have chosen [OpenSe
 
 ### Config
 
-Bare bones, we have no idea what we're doing. PR's welcome.
+See `config/wiki/extensions/Search.php` for our tweaks to the search configuration. Comments include why the changes have been made etc.
+
+Changes are based on [documentation found online](https://gerrit.wikimedia.org/g/mediawiki/extensions/CirrusSearch/%2B/HEAD/docs/settings.txt).
 
 ### Init
 

--- a/config/wiki/extensions/Search.php
+++ b/config/wiki/extensions/Search.php
@@ -40,6 +40,26 @@ $wgCirrusSearchReplicas = [
 
 $wgCirrusSearchUseCompletionSuggester = 'yes';
 
+// Weights: These are the default settings, but presented here for commentary/docs reasons
+// $wgCirrusSearchWeights = [
+//     'title'          => 20,
+//     'redirect'       => 15,
+//     'category'       => 8,
+//     'heading'        => 5,
+//     'opening_text'   => 3,
+//     'text'           => 1,
+//     'auxiliary_text' => 0.5,
+//     'file_text'      => 0.5,
+// ];
+
+// The following settings are based on information from: https://gerrit.wikimedia.org/g/mediawiki/extensions/CirrusSearch/%2B/HEAD/docs/settings.txt
+// And Prime reading each of the files, his head hurt reading them :'(
+
+// This switches the query builder profile to the "perfield_builder" one, which can score and rank each field separately.
+// E.g. title gets its own score, text gets its own, before they were flattened together
+// See: /CirrusSearch/profiles/FullTextQueryBuilderProfiles.config.php for more info, but I barely understand it - PRIME
+$wgCirrusSearchFullTextQueryBuilderProfile = 'perfield_builder';
+
 # TMP
 #$wgDisableSearchUpdate = true;
 ?>


### PR DESCRIPTION
My head hurts, 

This switches the query builder profile to the "perfield_builder" one, which can score and rank each field separately.
E.g. title gets its own score, text gets its own, before they were flattened together
See: /CirrusSearch/profiles/FullTextQueryBuilderProfiles.config.php for more info, but I barely understand it.

We can revert this EXTREMELY quickly so uh lets just do it *dabs*